### PR TITLE
Update usage.html

### DIFF
--- a/docs/forms/usage.html
+++ b/docs/forms/usage.html
@@ -270,7 +270,7 @@ $token-&gt;equals($other);   # false
 $other-&gt;equals($token);   # false
 
 $token-&gt;equals($another); # true
-$other-&gt;equals($another); # true
+$other-&gt;equals($another); # false
 # ...
 
 # Check token expiry


### PR DESCRIPTION
Why would `$other->equals($another);` ever be true if `$other->equals($token)` is not?